### PR TITLE
API first step: Prepare inMemoryDatabase for API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ struct Arguments {
 fn main() {
     let args = Arguments::from_args();
     tracing::info!("running data-server with {:#?}", args);
-    let _memory_database =
+    let dune_data =
         load_dune_data_into_memory(args.dune_data_file).expect("could not load data into memory");
-    println!("{:?}", _memory_database);
+    println!("{:?}", dune_data);
 }

--- a/src/models/in_memory_database.rs
+++ b/src/models/in_memory_database.rs
@@ -1,8 +1,54 @@
 extern crate serde_derive;
 use super::dune_json_formats::Data;
+use anyhow::Result;
 use chrono::prelude::*;
 use primitive_types::H160;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Mutex;
 
-#[derive(Debug, Clone)]
-pub struct InMemoryDatabase(pub HashMap<H160, Vec<Data>>, pub DateTime<Utc>);
+#[derive(Debug)]
+pub struct DatabaseStruct {
+    pub user_data: HashMap<H160, Vec<Data>>,
+    pub updated: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+pub struct InMemoryDatabase(pub Mutex<DatabaseStruct>);
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, PartialOrd)]
+#[serde(rename_all = "camelCase")]
+pub struct Profile {
+    total_trades: u64,
+    total_referrals: u64,
+    trade_volume_usd: f64,
+    referral_volume_usd: f64,
+    last_updated: Option<DateTime<Utc>>,
+}
+
+impl InMemoryDatabase {
+    pub fn get_profile_from_raw_data(&self, user: H160) -> Result<Profile> {
+        let guard = match self.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        match guard.user_data.get(&user) {
+            Some(data) => {
+                Ok(Profile {
+                    total_trades: data
+                        .iter()
+                        .map(|data| data.number_of_trades.unwrap_or(0u64))
+                        .sum(),
+                    total_referrals: 0u64, // <-- dummy
+                    trade_volume_usd: data
+                        .iter()
+                        .map(|data| data.cowswap_usd_volume.unwrap_or(0f64))
+                        .sum(),
+                    referral_volume_usd: 0f64, // <-- dummy
+                    last_updated: Some(guard.updated),
+                })
+            }
+            None => Ok(Default::default()),
+        }
+    }
+}


### PR DESCRIPTION
This PR  enables the reading of profiles - the final output of the API - out of  the InMemoryDatabase. For improved readablity, it replaces the tuple of the InMemoryDatabase with a struct: DatabaseStruct.

Testplan:
Unit tests only.

PS: I updated the user_data.json database file with the newest data, as the old file was broken.