### PR TITLE
adding docker setup for python cronjobs

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -7,3 +7,9 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_NAME" --password-stdin
 docker build -t "${DOCKERHUB_PROJECT}" -f docker/Dockerfile.binary .
 docker tag "${DOCKERHUB_PROJECT}" gnosispm/"${DOCKERHUB_PROJECT}":$1
 docker push gnosispm/"${DOCKERHUB_PROJECT}":$1
+
+# Build and tag dune-data-fetcher-image
+cd dune_data_api
+docker build -t "${DOCKERHUB_PROJECT}-fetcher" -f docker/Dockerfile.binary .
+docker tag "${DOCKERHUB_PROJECT}-fetcher" gnosispm/"${DOCKERHUB_PROJECT}-fetcher":$1
+docker push gnosispm/"${DOCKERHUB_PROJECT}-fetcher":$1

--- a/dune_api_scripts/docker/Dockerfile.binary
+++ b/dune_api_scripts/docker/Dockerfile.binary
@@ -1,0 +1,4 @@
+FROM python:3-alpine
+WORKDIR /usr/src/app
+COPY . .
+RUN pip install -r requirements.txt


### PR DESCRIPTION
This PR add a new docker image for the all the python scripts. This docker image will be run by the cronJobs.