### PR TITLE
Easy: Initialize tracing correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +136,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -360,6 +369,7 @@ name = "gpdata"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atty",
  "chrono",
  "futures",
  "hex",
@@ -372,6 +382,7 @@ dependencies = [
  "structopt",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "warp",
 ]
 
@@ -606,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +730,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -966,6 +992,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,10 +1134,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -1199,6 +1264,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1333,11 +1407,54 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ serde = { version = "1.0.104", features = ["derive"] }
 tokio = { version = "1.9", features = ["macros", "rt-multi-thread", "sync", "time"] }
 serde_derive = "1.0.127"
 serde_json = "1.0.66"
+atty = "0.2"
+tracing-subscriber = "0.2.23"
 serde_with = "1.9.4"
 structopt = "0.3.22"
 tracing = "0.1.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod dune_data_loading;
 pub mod in_memory_maintenance;
 pub mod models;
+pub mod tracing_helper;
 extern crate serde_derive;
 
 use models::in_memory_database::InMemoryDatabase;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use gpdata::dune_data_loading::load_dune_data_into_memory;
 use gpdata::in_memory_maintenance::in_memory_database_maintaince;
 use gpdata::models::in_memory_database::InMemoryDatabase;
 use gpdata::serve_task;
+use gpdata::tracing_helper::initialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -9,6 +10,8 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Arguments {
+    #[structopt(long, env = "LOG_FILTER", default_value = "warn,debug,info")]
+    pub log_filter: String,
     #[structopt(long, env = "BIND_ADDRESS", default_value = "0.0.0.0:8080")]
     bind_address: SocketAddr,
     #[structopt(long, env = "DUNE_DATA_FILE", default_value = "./user_data.json")]
@@ -18,7 +21,8 @@ struct Arguments {
 #[tokio::main]
 async fn main() {
     let args = Arguments::from_args();
-    tracing::debug!("running data-server with {:#?}", args);
+    initialize(args.log_filter.as_str());
+    tracing::info!("running data-server with {:#?}", args);
     let dune_download_file = args.dune_data_file;
 
     let dune_data = load_dune_data_into_memory(dune_download_file.clone())

--- a/src/tracing_helper.rs
+++ b/src/tracing_helper.rs
@@ -1,0 +1,34 @@
+use std::{
+    panic::{self, PanicInfo},
+    thread,
+};
+use tracing_subscriber::fmt::time::ChronoUtc;
+
+/// Initializes tracing setup that is shared between the binaries.
+/// `env_filter` has similar syntax to env_logger. It is documented at
+/// https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html
+pub fn initialize(env_filter: &str) {
+    // This is what kibana uses to separate multi line log messages.
+    let time_format_string = "%Y-%m-%dT%H:%M:%S%.3fZ";
+    tracing_subscriber::fmt::fmt()
+        .with_timer(ChronoUtc::with_format(String::from(time_format_string)))
+        .with_env_filter(env_filter)
+        .with_ansi(atty::is(atty::Stream::Stdout))
+        .init();
+    set_panic_hook();
+}
+
+// Sets a panic hook so panic information is logged in addition to the default panic printer.
+fn set_panic_hook() {
+    let default_hook = panic::take_hook();
+    let hook = move |info: &PanicInfo| {
+        let thread = thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>");
+        // It is not possible for our custom hook to print a full backtrace on stable rust. To not
+        // lose this information we call the default panic handler which prints the full backtrace.
+        // The preceding log makes kibana consider this a multi line log message.
+        tracing::error!("thread '{}' {}:", thread_name, info);
+        default_hook(info);
+    };
+    panic::set_hook(Box::new(hook));
+}


### PR DESCRIPTION
Previously, the printing of tracing was not working. It needed to be initialised. I copied the code from -gp-v2-services.

testplan:
run 
```
cargo run
```
and see the logs.