### PR TITLE
Small corrections for compatiblity

### DIFF
--- a/dune_api_scripts/queries.py
+++ b/dune_api_scripts/queries.py
@@ -140,7 +140,7 @@ def build_query_for_affiliate_data(startDate, endDate):
 
     -- Final table
     Select
-        CASE WHEN ar.owner is NUll THEN tr.owner::TEXT ELSE ar.owner END as owner,
+        Replace(CASE WHEN ar.owner is NUll THEN tr.owner::TEXT ELSE ar.owner END, '\\x', '0x') as owner,
         CASE WHEN ar.day is NUll THEN tr.day ELSE ar.day END as day,
         total_referred_volume,
         nr_of_referrals,

--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 import os
+import time
 from utils import dune_from_environment
 
 
@@ -21,7 +22,7 @@ data = dune.query_result(result_id)
 app_data = data["data"]["get_result_by_result_id"]
 data_set = {
     "app_data": app_data,
-    "time_of_download": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+    "time_of_download": int(time.mktime(datetime.now().timetuple()))
 }
 
 # write to file, if non-empty

--- a/dune_api_scripts/utils.py
+++ b/dune_api_scripts/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 from duneanalytics import DuneAnalytics
 from pathlib import Path
 from datetime import datetime
@@ -20,14 +21,15 @@ def parse_data_from_dune_query(data):
         user_data[0]["data"]["day"][0:10], '%Y-%m-%d')
     return {
         "user_data": user_data,
-        "time_of_download": date_of_data_creation.strftime("%d/%m/%Y %H:%M:%S")
+        "time_of_download": int(time.mktime(date_of_data_creation.timetuple()))
     }
 
 
 def store_as_json_file(data_set):
     file_path = Path(os.environ['DUNE_DATA_FOLDER'] + "/user_data/")
     os.makedirs(file_path,  exist_ok=True)
-    file_name = Path("user_data_from{}.json".format(datetime.now()))
+    file_name = Path("user_data_from{}.json".format(
+        data_set["time_of_download"]))
     with open(os.path.join(file_path, file_name), 'w+', encoding='utf-8') as f:
         json.dump(data_set, f, ensure_ascii=False, indent=4)
     print("Written updates into: " + os.path.join(file_path, file_name))

--- a/src/dune_data_loading.rs
+++ b/src/dune_data_loading.rs
@@ -58,7 +58,7 @@ mod tests {
                     {
                         "data": {
                             "cowswap_usd_volume": 474.26231998787733,
-                            "month": "2021-05",
+                            "day": "2021-05-05",
                             "number_of_trades": 3,
                             "owner": "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737",
                             "usd_volume_all_exchanges": null

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ struct Arguments {
     pub log_filter: String,
     #[structopt(long, env = "BIND_ADDRESS", default_value = "0.0.0.0:8080")]
     bind_address: SocketAddr,
-    #[structopt(long, env = "DUNE_DATA_FILE", default_value = "./user_data.json")]
-    dune_data_file: String,
+    #[structopt(long, env = "DUNE_DATA_FOLDER", default_value = "./data/dune_data/")]
+    dune_data_folder: String,
 }
 
 #[tokio::main]
@@ -23,12 +23,12 @@ async fn main() {
     let args = Arguments::from_args();
     initialize(args.log_filter.as_str());
     tracing::info!("running data-server with {:#?}", args);
-    let dune_download_file = args.dune_data_file;
-
+    let dune_download_folder = args.dune_data_folder;
+    let dune_download_file =
+        String::from(dune_download_folder.clone() + "user_data/user_data.json");
     let dune_data = load_dune_data_into_memory(dune_download_file.clone())
-        .expect("could not load data into memory");
+        .expect("could not laod dune data into memory");
     let memory_database = Arc::new(InMemoryDatabase(Mutex::new(dune_data)));
-
     let serve_task = serve_task(memory_database.clone(), args.bind_address);
     let maintance_task = tokio::task::spawn(in_memory_database_maintaince(
         memory_database.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,7 @@ async fn main() {
     initialize(args.log_filter.as_str());
     tracing::info!("running data-server with {:#?}", args);
     let dune_download_folder = args.dune_data_folder;
-    let dune_download_file =
-        String::from(dune_download_folder.clone() + "user_data/user_data.json");
+    let dune_download_file = dune_download_folder.clone() + "user_data/user_data.json";
     let dune_data = load_dune_data_into_memory(dune_download_file.clone())
         .expect("could not laod dune data into memory");
     let memory_database = Arc::new(InMemoryDatabase(Mutex::new(dune_data)));

--- a/src/models/dune_json_formats.rs
+++ b/src/models/dune_json_formats.rs
@@ -19,7 +19,7 @@ pub struct UserData {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd)]
 pub struct Data {
     pub cowswap_usd_volume: Option<f64>,
-    pub month: String,
+    pub day: String,
     pub number_of_trades: Option<u64>,
     pub owner: H160,
     pub usd_volume_all_exchanges: Option<f64>,
@@ -51,7 +51,7 @@ mod tests {
         });
         let data = Data {
             cowswap_usd_volume: Some(474.26231998787733f64),
-            month: String::from("2021-05"),
+            day: String::from("2021-05-05"),
             number_of_trades: Some(3u64),
             owner: "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737"
                 .parse()

--- a/src/models/dune_json_formats.rs
+++ b/src/models/dune_json_formats.rs
@@ -39,7 +39,7 @@ mod tests {
                     {
                         "data": {
                             "cowswap_usd_volume": 474.26231998787733,
-                            "month": "2021-05",
+                            "day": "2021-05-05",
                             "number_of_trades": 3,
                             "owner": "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737",
                             "usd_volume_all_exchanges": null


### PR DESCRIPTION
Tiny changes, such that the rust code can actually parse the query results 

testplan:
run:
```
python3 modify_and_execute_dune_query_for_todays_trading_data.py
python3 store_query_result_for_todays_trading_data.py           
```
and then 
```
cargo run
```