### PR TITLE
Implementing the parsing of referrals

### DIFF
--- a/src/dune_data_loading.rs
+++ b/src/dune_data_loading.rs
@@ -71,7 +71,12 @@ mod tests {
                             "day": "2021-05-05",
                             "number_of_trades": 3,
                             "owner": "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737",
-                            "usd_volume_all_exchanges": null
+                            "usd_volume_all_exchanges": null,
+                            "referrals": [
+                                "0x94e61b6b34f2bb82d59a57dba08243d33a083c7e",
+                                "0x9dcfad0b490378826774cb402e4959fc39c0a9a4"
+                            ],
+                            "total_referred_volume": 247.135594313237,
                         },
                         "__typename": "get_result_template"
                     },

--- a/src/models/dune_json_formats.rs
+++ b/src/models/dune_json_formats.rs
@@ -22,7 +22,8 @@ pub struct Data {
     pub day: String,
     pub number_of_trades: Option<u64>,
     pub owner: H160,
-    pub usd_volume_all_exchanges: Option<f64>,
+    pub referrals: Vec<H160>,
+    pub total_referred_volume: Option<f64>,
 }
 
 #[cfg(test)]
@@ -39,10 +40,14 @@ mod tests {
                     {
                         "data": {
                             "cowswap_usd_volume": 474.26231998787733,
-                            "day": "2021-05-05",
+                            "day": "2021-10-18T00:00:00+00:00",
                             "number_of_trades": 3,
-                            "owner": "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737",
-                            "usd_volume_all_exchanges": null
+                            "owner": "0x36416d81e590ff67370e4523b9cd3257aa0a853c",
+                            "referrals": [
+                                "0x94e61b6b34f2bb82d59a57dba08243d33a083c7e",
+                                "0x9dcfad0b490378826774cb402e4959fc39c0a9a4"
+                            ],
+                            "total_referred_volume": 247.135594313237,
                         },
                         "__typename": "get_result_template"
                     }
@@ -51,12 +56,20 @@ mod tests {
         });
         let data = Data {
             cowswap_usd_volume: Some(474.26231998787733f64),
-            day: String::from("2021-05-05"),
+            day: String::from("2021-10-18T00:00:00+00:00"),
             number_of_trades: Some(3u64),
-            owner: "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737"
+            owner: "0x36416d81e590ff67370e4523b9cd3257aa0a853c"
                 .parse()
                 .unwrap(),
-            usd_volume_all_exchanges: None,
+            referrals: vec![
+                "0x94e61b6b34f2bb82d59a57dba08243d33a083c7e"
+                    .parse()
+                    .unwrap(),
+                "0x9dcfad0b490378826774cb402e4959fc39c0a9a4"
+                    .parse()
+                    .unwrap(),
+            ],
+            total_referred_volume: Some(247.135594313237f64),
         };
         let user_data = UserData { data };
         let expected_value = DuneJson {


### PR DESCRIPTION
Previously, the referrals were not accounted correctly. Now, the dune query downloads the actual address referred per referrer and they are index by the backend. 

Upon api requests, we count the number of different referrals, and serve the number via the api.

Testplan:
unit tests only.