### PR TITLE
Get newest app data from solveable orders

### DIFF
--- a/src/referral_maintenance.rs
+++ b/src/referral_maintenance.rs
@@ -52,7 +52,7 @@ pub async fn maintenaince_tasks(
     // 1.2: Load app_data from solvable_orders api
     match load_current_app_data_of_solvable_orders().await {
         Ok(vec_with_app_data) => vec_with_all_app_data.extend(vec_with_app_data),
-        Err(err) => tracing::debug!("error while downloading the solvable orders: {:}", err),
+        Err(err) => tracing::warn!("error while downloading the solvable orders: {:}", err),
     };
     // 2nd step: Store app_data in ReferralStore, if not yet existing
     for app_data in vec_with_all_app_data {


### PR DESCRIPTION
Currently, we would get the app-data from the dune-queries. Though going that route takes additional time. It's much easier to always get the newest dune data from the solvable orders, instead of waiting for the dune queries. This PR implements this fetching method, additional to the existing one.

Later on, I would like to make a new PR to the gp-v2-services, that just provides all app_data and then we don't need the dune query at all for this data.

Testplan:
unit tests