### PR TITLE
Parameterizing the dune query IDs

### DIFF
--- a/dune_api_scripts/execute_dune_query_for_all_app_data.py
+++ b/dune_api_scripts/execute_dune_query_for_all_app_data.py
@@ -1,7 +1,9 @@
+import os
 from utils import dune_from_environment
 
 # initialize the enviroment
 dune = dune_from_environment()
 
 # execute query again
-dune.execute_query(query_id=142824)
+query_id = os.getenv('QUERY_ID_ALL_APP_DATA', 142824)
+dune.execute_query(query_id)

--- a/dune_api_scripts/modify_and_execute_dune_query_for_entire_history_trading_data.py
+++ b/dune_api_scripts/modify_and_execute_dune_query_for_entire_history_trading_data.py
@@ -1,3 +1,4 @@
+import os
 from duneanalytics import DuneAnalytics
 import datetime
 from utils import dune_from_environment
@@ -26,7 +27,8 @@ dune = dune_from_environment()
 query = build_query_for_todays_trading_volume()
 
 # update query in dune
-dune.initiate_new_query(query_id=157348, query=query)
+query_id = os.getenv('QUERY_ID_ENTIRE_HISTORY_TRADING_DATA', 157348)
+dune.initiate_new_query(query_id, query=query)
 
 # run query in dune
-dune.execute_query(query_id=157348)
+dune.execute_query(query_id)

--- a/dune_api_scripts/modify_and_execute_dune_query_for_todays_trading_data.py
+++ b/dune_api_scripts/modify_and_execute_dune_query_for_todays_trading_data.py
@@ -1,3 +1,4 @@
+import os
 from utils import dune_from_environment
 from queries import build_query_for_affiliate_data
 import datetime
@@ -20,7 +21,8 @@ dune = dune_from_environment()
 query = build_query_for_todays_trading_volume()
 
 # update query in dune
-dune.initiate_new_query(query_id=135804, query=query)
+query_id = os.getenv('QUERY_ID_TODAYS_TRADING_DATA', 135804)
+dune.initiate_new_query(query_id, query=query)
 
 # run query in dune
-dune.execute_query(query_id=135804)
+dune.execute_query(query_id)

--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -13,7 +13,8 @@ os.makedirs(entire_history_path, exist_ok=True)
 dune = dune_from_environment()
 
 # fetch query result id using query id
-result_id = dune.query_result_id(query_id=142824)
+query_id = os.getenv('QUERY_ID_ALL_APP_DATA', 142824)
+result_id = dune.query_result_id(query_id)
 
 # fetch query result
 data = dune.query_result(result_id)

--- a/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
@@ -1,4 +1,5 @@
 import json
+import os
 from utils import dune_from_environment
 from utils import check_whether_entire_history_file_was_already_downloade
 from utils import parse_data_from_dune_query
@@ -11,7 +12,8 @@ file_entire_history = check_whether_entire_history_file_was_already_downloade()
 dune = dune_from_environment()
 
 # fetch query result id using query id
-result_id = dune.query_result_id(query_id=157348)
+query_id = os.getenv('QUERY_ID_ENTIRE_HISTORY_TRADING_DATA', 157348)
+result_id = dune.query_result_id(query_id)
 
 # fetch query result
 data = dune.query_result(result_id)

--- a/dune_api_scripts/store_query_result_for_todays_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_todays_trading_data.py
@@ -1,10 +1,12 @@
+import os
 from utils import parse_data_from_dune_query, store_as_json_file, dune_from_environment
 
 # initialize the enviroment
 dune = dune_from_environment()
 
 # fetch query result id using query id
-result_id = dune.query_result_id(query_id=135804)
+query_id = os.getenv('QUERY_ID_TODAYS_TRADING_DATA', 135804)
+result_id = dune.query_result_id(query_id)
 
 # fetch query result
 data = dune.query_result(result_id)


### PR DESCRIPTION
I am introducing parameters for the dune query ids, such that we have different ones in production and staging.


testplan:
non; I tested locally that the scripts still result in the same query