### PR TITLE
[Easy] Correcting parsing of time: consider timezones

### DIFF
--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -23,7 +23,7 @@ data = dune.query_result(result_id)
 app_data = data["data"]["get_result_by_result_id"]
 data_set = {
     "app_data": app_data,
-    "time_of_download": int(time.mktime(datetime.strptime(data["data"]["query_results"][0]["generated_at"][:-6], '%Y-%m-%dT%H:%M:%S.%f').timetuple()))
+    "time_of_download": int(datetime.fromisoformat(data["data"]["query_results"][0]["generated_at"]).timestamp())
 }
 
 # write to file, if non-empty

--- a/dune_api_scripts/utils.py
+++ b/dune_api_scripts/utils.py
@@ -17,8 +17,8 @@ def dune_from_environment():
 
 def parse_data_from_dune_query(data):
     user_data = data["data"]["get_result_by_result_id"]
-    date_of_data_execution = time.mktime(datetime.strptime(data["data"]["query_results"][0]
-                                                           ["generated_at"][:-6], '%Y-%m-%dT%H:%M:%S.%f').timetuple())
+    date_of_data_execution = datetime.fromisoformat(
+        data["data"]["query_results"][0]["generated_at"]).timestamp()
     return {
         "user_data": user_data,
         "time_of_download": int(date_of_data_execution)


### PR DESCRIPTION
`timetuple()` wouldn't store the offset due to time zone, hence I need a different function for the exact timing.

https://stackoverflow.com/questions/31147999/is-time-mktime-timezone-free-in-python