### PR TITLE
End of day considerations

### DIFF
--- a/dune_api_scripts/modify_and_execute_dune_query_for_todays_trading_data.py
+++ b/dune_api_scripts/modify_and_execute_dune_query_for_todays_trading_data.py
@@ -8,7 +8,7 @@ FREQUENCY_OF_CRON_JOB_IN_MINUTES = 5
 
 def build_query_for_todays_trading_volume():
 
-    today = datetime.date.today().timedelta(mins=-FREQUENCY_OF_CRON_JOB_IN_MINUTES)
+    today = datetime.date.today() - datetime.timedelta(minutes=FREQUENCY_OF_CRON_JOB_IN_MINUTES)
     tomorrow = today + datetime.timedelta(days=1)
     startDate = "'{}'".format(today.strftime("%Y-%m-%d"))
     endDate = "'{}'".format(tomorrow.strftime("%Y-%m-%d"))


### PR DESCRIPTION
The "daily cronjob" only downloads the data of the "current day". That also means that on a new day, at 00:01, the cronjob would just download the data of 1 minute, and the last 5 minutes from the previous day might be missed. 
Hence, I am shifting the calculation of the current day by 5 minutes, hence, at 00:01, we will calculate the data for all of the last day.


----
Ben you are right, actually I am already using timedelta already in some places. Let me see how I can make it more consistent.