### PR TITLE
Parsing dunes iso format in all cases

### DIFF
--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 import os
 import time
-from utils import dune_from_environment
+from utils import dune_from_environment, parse_dune_iso_format_to_timestamp
 
 
 entire_history_path = Path(os.environ['DUNE_DATA_FOLDER'] + "/app_data/")
@@ -23,7 +23,7 @@ data = dune.query_result(result_id)
 app_data = data["data"]["get_result_by_result_id"]
 data_set = {
     "app_data": app_data,
-    "time_of_download": int(datetime.fromisoformat(data["data"]["query_results"][0]["generated_at"]).timestamp())
+    "time_of_download": int(parse_dune_iso_format_to_timestamp(data["data"]["query_results"][0]["generated_at"]))
 }
 
 # write to file, if non-empty

--- a/dune_api_scripts/utils.py
+++ b/dune_api_scripts/utils.py
@@ -15,10 +15,16 @@ def dune_from_environment():
     return dune
 
 
+def parse_dune_iso_format_to_timestamp(dune_iso_string):
+    # Dune is incompatible with the iso format, as sometimes the amount of millisecs are not represented with the right amount of digits.
+    # Hence, we cut of the provided time and set the end of the string to '.000000+00:00'.
+    return datetime.fromisoformat(dune_iso_string[0:19]+'.000000+00:00').timestamp()
+
+
 def parse_data_from_dune_query(data):
     user_data = data["data"]["get_result_by_result_id"]
-    date_of_data_execution = datetime.fromisoformat(
-        data["data"]["query_results"][0]["generated_at"]).timestamp()
+    date_of_data_execution = parse_dune_iso_format_to_timestamp(
+        data["data"]["query_results"][0]["generated_at"])
     return {
         "user_data": user_data,
         "time_of_download": int(date_of_data_execution)


### PR DESCRIPTION
Dune is sometimes not providing the last digit of the milliseconds time, ie '2021-10-27T03:51:30.27525+00:00' without '2021-10-27T03:51:30.27525**0**+00:00'
This causes issues during parsing:
```
>>> datetime.fromisoformat('2021-10-27T03:51:30.27525+00:00')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid isoformat string: '2021-10-27T03:51:30.27525+00:00'
>>> datetime.fromisoformat('2021-10-27T03:51:30.275250+00:00')
datetime.datetime(2021, 10, 27, 3, 51, 30, 275250, tzinfo=datetime.timezone.utc)
```