### PR TITLE
Starting service with non-existing dictionary

### DIFF
--- a/src/dune_data_loading.rs
+++ b/src/dune_data_loading.rs
@@ -10,9 +10,10 @@ use std::fs::{read_dir, File};
 use std::io::Read;
 use std::path::Path;
 
-pub fn load_dune_data_into_memory<P: AsRef<Path>>(path: P) -> Result<DatabaseStruct> {
+pub fn load_dune_data_into_memory<P: Clone + AsRef<Path>>(path: P) -> Result<DatabaseStruct> {
     let mut memory_database: HashMap<H160, Vec<Data>> = HashMap::new();
     let mut date = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+    std::fs::create_dir_all(path.clone())?;
     for entry in read_dir(path)? {
         let entry = entry?;
         let dune_json = serde_json::from_str(&read_dune_data_from_file(entry.path())?)?;

--- a/src/referral_maintenance.rs
+++ b/src/referral_maintenance.rs
@@ -45,7 +45,7 @@ pub async fn maintenaince_tasks(
     ) {
         Ok(vec) => vec,
         Err(err) => {
-            tracing::error!("Could not load distinct app data, due to: {:?}", err);
+            tracing::debug!("Could not load distinct app data, due to: {:?}", err);
             return Ok(());
         }
     };


### PR DESCRIPTION
Create the path dictionary, if non existing

----
testplan:

1. delete the file structure:
2. Run the service:
```
cargo run                               
    Finished dev [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/gpdata`
2021-11-09T18:02:12.840Z  INFO gpdata: running data-server with Arguments {
    log_filter: "warn,gpdata=debug,info",
    bind_address: 0.0.0.0:8080,
    dune_data_folder: "./data/dune_data/",
    referral_data_folder: "./data/referral_data/",
}
2021-11-09T18:02:12.841Z  INFO gpdata: serving dune data address=0.0.0.0:8080
2021-11-09T18:02:12.842Z DEBUG gpdata::referral_maintenance: Could not load distinct app data, due to: No such file or directory (os error 2)
```

create the app data file by running:
```
export DUNE_DATA_FOLDER=./data/dune_data/
export APP_DATA_REFERRAL_RELATION_FILE=./data/referral_data/app_data_referral_relationship.json
export DUNE_USER=alex@gnosis.pm     
export DUNE_PASSWORD=<pwd>
python3 -m dune_api_scripts.store_query_result_all_distinct_app_data
```

And then suddenly in the service the msg:
```
2021-11-09T18:02:12.842Z DEBUG gpdata::referral_maintenance: Could not load distinct app data, due to: No such file or directory (os error 2)

```

will disappear and be replaced by:
```
2021-11-09T18:02:28.098Z DEBUG gpdata::referral_maintenance: Newly fetched app data is: [0x487b02c558d729abaf3ecf17881a4181e5bc2446429a0995142297e897b6eb37]
```
