### PR TITLE
More secure referral loading

### DIFF
--- a/src/referral_maintenance.rs
+++ b/src/referral_maintenance.rs
@@ -289,6 +289,7 @@ mod tests {
             (&"./data/dune_data/").to_string(),
             (&"./data/referral_data/").to_string(),
             2u64,
+            &mut true,
         )
         .await;
         assert!(result.is_ok());


### PR DESCRIPTION
When syncing the referrals for the first time with IPFS, it can happen that not all referrals are retrieved ( e.g. failed api requests). 
This incomplete data should then not be used to create the first query for the whole history. Hence, this PR implements a new flag: `referrals_fully_synced` that is only activated, if the code tried to download the data from ipfs for serval times.
Only if the flag is true, then we will create the app_data_referral_relationship and the dune scripts will become active.

Testplan: 
none