### PR TITLE
Parse Entire AppData

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use gpdata::in_memory_maintenance::in_memory_database_maintaince;
 use gpdata::models::in_memory_database::DatabaseStruct;
 use gpdata::models::in_memory_database::InMemoryDatabase;
 use gpdata::models::referral_store::ReferralStore;
-use gpdata::referral_maintenance::referral_maintainance;
+use gpdata::referral_maintenance::referral_maintenance;
 use gpdata::serve_task;
 use gpdata::tracing_helper::initialize;
 use std::net::SocketAddr;
@@ -45,7 +45,7 @@ async fn main() {
         health,
     ));
     let referral_store = ReferralStore::new(Vec::new());
-    let referral_maintance_task = tokio::task::spawn(referral_maintainance(
+    let referral_maintance_task = tokio::task::spawn(referral_maintenance(
         Arc::new(referral_store),
         dune_download_folder.clone(),
         referral_data_folder,

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -8,7 +8,6 @@ use serde_with::serde_as;
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 pub struct Referrer {
     pub address: H160,
-    pub kind: String,
     pub version: String,
 }
 
@@ -35,16 +34,33 @@ mod tests {
 
     #[test]
     fn test_loading_json_and_reading_referral() {
-        let value = json!(
-                {"version":"1.0.0","appCode":"CowSwap","metadata":{"environment": "production", "referrer":{"kind":"referrer","address":"0x8c35B7eE520277D14af5F6098835A584C337311b","version":"1.0.0"}}}
-        );
+        let value = json!({
+                "version":"1.2.3",
+                "appCode":"MooSwap",
+                "metadata":{
+                    "environment": "production",
+                    "referrer":{
+                        "kind":"referrer",
+                        "address":"0x8c35B7eE520277D14af5F6098835A584C337311b",
+                        "version":"6.6.6"
+                }
+            }
+        });
         let json: AppData = serde_json::from_value(value).unwrap();
-        let expected_referral: H160 = "0x8c35B7eE520277D14af5F6098835A584C337311b"
-            .parse()
-            .unwrap();
-        assert_eq!(
-            json.metadata.unwrap().referrer.unwrap().address,
-            expected_referral
-        );
+        let expected = AppData {
+            version: "1.2.3".to_string(),
+            app_code: "MooSwap".to_string(),
+            metadata: Some(Metadata {
+                environment: Some("production".to_string()),
+                referrer: Some(Referrer {
+                    address: "0x8c35B7eE520277D14af5F6098835A584C337311b"
+                        .parse()
+                        .unwrap(),
+                    version: "6.6.6".to_string(),
+                }),
+            }),
+        };
+
+        assert_eq!(json, expected);
     }
 }

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -8,11 +8,14 @@ use serde_with::serde_as;
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 pub struct Referrer {
     pub address: H160,
+    pub kind: String,
+    pub version: String,
 }
 
 #[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 pub struct Metadata {
+    pub environment: Option<String>,
     pub referrer: Option<Referrer>,
 }
 
@@ -20,6 +23,8 @@ pub struct Metadata {
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AppData {
+    pub version: String,
+    pub app_code: String,
     pub metadata: Option<Metadata>,
 }
 #[cfg(test)]
@@ -31,7 +36,7 @@ mod tests {
     #[test]
     fn test_loading_json_and_reading_referral() {
         let value = json!(
-                {"version":"1.0.0","appCode":"CowSwap","metadata":{"referrer":{"kind":"referrer","address":"0x8c35B7eE520277D14af5F6098835A584C337311b","version":"1.0.0"}}}
+                {"version":"1.0.0","appCode":"CowSwap","metadata":{"environment": "production", "referrer":{"kind":"referrer","address":"0x8c35B7eE520277D14af5F6098835A584C337311b","version":"1.0.0"}}}
         );
         let json: AppData = serde_json::from_value(value).unwrap();
         let expected_referral: H160 = "0x8c35B7eE520277D14af5F6098835A584C337311b"


### PR DESCRIPTION
This PR extends the AppData and MetaData and Referrer structs so that serde (in all its glory) can parse all content from AppData. To be used in the future when populating an AppData table in Dune.