### PR TITLE
New api format

### DIFF
--- a/dune_api_scripts/duneanalytics.py
+++ b/dune_api_scripts/duneanalytics.py
@@ -90,8 +90,6 @@ class DuneAnalytics:
 
         query_data = {
             "operationName": "UpsertQuery",
-            # pylint: disable=line-too-long
-            "query": "mutation UpsertQuery($session_id: Int!, $object: queries_insert_input!, $on_conflict: queries_on_conflict!, $favs_last_24h: Boolean! = false, $favs_last_7d: Boolean! = false, $favs_last_30d: Boolean! = false, $favs_all_time: Boolean! = true) {\n  insert_queries_one(object: $object, on_conflict: $on_conflict) {\n    ...Query\n    favorite_queries(where: {user_id: {_eq: $session_id}}, limit: 1) {\n      created_at\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment Query on queries {\n  id\n  dataset_id\n  name\n  description\n  query\n  private_to_group_id\n  is_temp\n  is_archived\n  created_at\n  updated_at\n  schedule\n  tags\n  parameters\n  user {\n    ...User\n    __typename\n  }\n  visualizations {\n    id\n    type\n    name\n    options\n    created_at\n    __typename\n  }\n  favorite_queries_aggregate @include(if: $favs_all_time) {\n    aggregate {\n      count\n      __typename\n    }\n    __typename\n  }\n  query_favorite_count_last_24h @include(if: $favs_last_24h) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_7d @include(if: $favs_last_7d) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_30d @include(if: $favs_last_30d) {\n    favorite_count\n    __typename\n  }\n  __typename\n}\n\nfragment User on users {\n  id\n  name\n  profile_image_url\n  __typename\n}\n",
             "variables": {
                 "favs_last_24h": False,
                 "favs_last_7d": False,
@@ -111,31 +109,13 @@ class DuneAnalytics:
                     "parameters": [],
                     "visualizations": {
                         "data": [],
-                        "on_conflict": {
-                            "constraint": "visualizations_pkey",
-                            "update_columns": [
-                                "name",
-                                "options"
-                            ]
-                        }
+                        "on_conflict": {"constraint": "visualizations_pkey", "update_columns": ["name", "options"]}
                     }
                 },
-                "on_conflict": {
-                    "constraint": "queries_pkey",
-                    "update_columns": [
-                        "dataset_id",
-                        "name",
-                        "description",
-                        "query",
-                        "schedule",
-                        "is_archived",
-                        "is_temp",
-                        "tags",
-                        "parameters"
-                    ]
-                },
+                "on_conflict": {"constraint": "queries_pkey", "update_columns": ["dataset_id", "name", "description", "query", "schedule", "is_archived", "is_temp", "tags", "parameters"]},
                 "session_id": 84
-            }
+            },
+            "query": "mutation UpsertQuery($session_id: Int!, $object: queries_insert_input!, $on_conflict: queries_on_conflict!, $favs_last_24h: Boolean! = false, $favs_last_7d: Boolean! = false, $favs_last_30d: Boolean! = false, $favs_all_time: Boolean! = true) {\n  insert_queries_one(object: $object, on_conflict: $on_conflict) {\n    ...Query\n    favorite_queries(where: {user_id: {_eq: $session_id}}, limit: 1) {\n      created_at\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment Query on queries {\n  id\n  dataset_id\n  name\n  description\n  query\n  private_to_group_id\n  is_temp\n  is_archived\n  created_at\n  updated_at\n  schedule\n  tags\n  parameters\n  user {\n    ...User\n    __typename\n  }\n  visualizations {\n    id\n    type\n    name\n    options\n    created_at\n    __typename\n  }\n  query_favorite_count_all @include(if: $favs_all_time) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_24h @include(if: $favs_last_24h) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_7d @include(if: $favs_last_7d) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_30d @include(if: $favs_last_30d) {\n    favorite_count\n    __typename\n  }\n  __typename\n}\n\nfragment User on users {\n  id\n  name\n  profile_image_url\n  __typename\n}\n"
         }
 
         self.session.headers.update({'authorization': f'Bearer {self.token}'})

--- a/dune_api_scripts/duneanalytics.py
+++ b/dune_api_scripts/duneanalytics.py
@@ -109,12 +109,20 @@ class DuneAnalytics:
                     "parameters": [],
                     "visualizations": {
                         "data": [],
-                        "on_conflict": {"constraint": "visualizations_pkey", "update_columns": ["name", "options"]}
+                        "on_conflict": {
+                            "constraint": "visualizations_pkey",
+                            "update_columns": ["name", "options"]
+                        }
                     }
                 },
-                "on_conflict": {"constraint": "queries_pkey", "update_columns": ["dataset_id", "name", "description", "query", "schedule", "is_archived", "is_temp", "tags", "parameters"]},
+                "on_conflict": {
+                    "constraint": "queries_pkey",
+                    "update_columns": ["dataset_id", "name", "description", "query", "schedule",
+                                       "is_archived", "is_temp", "tags", "parameters"]
+                },
                 "session_id": 84
             },
+            # pylint: disable=line-too-long
             "query": "mutation UpsertQuery($session_id: Int!, $object: queries_insert_input!, $on_conflict: queries_on_conflict!, $favs_last_24h: Boolean! = false, $favs_last_7d: Boolean! = false, $favs_last_30d: Boolean! = false, $favs_all_time: Boolean! = true) {\n  insert_queries_one(object: $object, on_conflict: $on_conflict) {\n    ...Query\n    favorite_queries(where: {user_id: {_eq: $session_id}}, limit: 1) {\n      created_at\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment Query on queries {\n  id\n  dataset_id\n  name\n  description\n  query\n  private_to_group_id\n  is_temp\n  is_archived\n  created_at\n  updated_at\n  schedule\n  tags\n  parameters\n  user {\n    ...User\n    __typename\n  }\n  visualizations {\n    id\n    type\n    name\n    options\n    created_at\n    __typename\n  }\n  query_favorite_count_all @include(if: $favs_all_time) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_24h @include(if: $favs_last_24h) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_7d @include(if: $favs_last_7d) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_30d @include(if: $favs_last_30d) {\n    favorite_count\n    __typename\n  }\n  __typename\n}\n\nfragment User on users {\n  id\n  name\n  profile_image_url\n  __typename\n}\n"
         }
 


### PR DESCRIPTION
Dune changed the format for query uploads. 

This PR adapts to the new format.

Test plan:
```
source .env
python -m dune_api_scripts.modify_and_execute_dune_query_for_todays_trading_data
```
and see that there is no longer an error.

