### PR TITLE
Fix for wrong date of download

### DIFF
--- a/dune_api_scripts/store_query_result_for_todays_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_todays_trading_data.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     dune = dune_from_environment()
 
     # fetch query result id using query id
-    query_id = int(os.getenv('QUERY_ID_TODAYS_TRADING_DATA', "135804"))
+    query_id = int(os.getenv('QUERY_ID_TODAYS_TRADING_DATA', "249240"))
     result_id = dune.query_result_id(query_id)
 
     # fetch query result

--- a/dune_api_scripts/utils.py
+++ b/dune_api_scripts/utils.py
@@ -54,7 +54,17 @@ def store_as_json_file(data_set):
     #     datetime.fromtimestamp(data_set["time_of_download"]).date()
     #  )
     download_day_timestamp = (data_set["time_of_download"] // (24 * 60 * 60)) * (
-            24 * 60 * 60)
+        24 * 60 * 60)
+    if not data_set["user_data"]:
+        print("Empty download")
+        sys.exit()
+    if 'day' not in data_set["user_data"][0]['data']:
+        print("Invalid download: {file}".format(file=data_set))
+        sys.exit()
+    downloaded_data_timestamp = int(parse_dune_iso_format_to_timestamp(
+        data_set["user_data"][0]['data']['day']))
+    download_day_timestamp = (downloaded_data_timestamp // (24 * 60 * 60)) * (
+        24 * 60 * 60)
     file_name = Path(f'user_data_from{download_day_timestamp}.json')
     with open(os.path.join(file_path, file_name), 'w+', encoding='utf-8') as file:
         json.dump(data_set, file, ensure_ascii=False, indent=4)
@@ -106,5 +116,6 @@ def ensure_that_download_is_recent(timestamp: int, max_time_diff: int):
     """
     now = int(time.time())
     if timestamp < now - max_time_diff:
-        print(f'query result not from the last {max_time_diff / 60} mins, aborting')
+        print(
+            f'query result not from the last {max_time_diff / 60} mins, aborting')
         sys.exit()

--- a/dune_api_scripts/utils.py
+++ b/dune_api_scripts/utils.py
@@ -59,7 +59,7 @@ def store_as_json_file(data_set):
         print("Empty download")
         sys.exit()
     if 'day' not in data_set["user_data"][0]['data']:
-        print("Invalid download: {file}".format(file=data_set))
+        print(f"Invalid download: {data_set}")
         sys.exit()
     downloaded_data_timestamp = int(parse_dune_iso_format_to_timestamp(
         data_set["user_data"][0]['data']['day']))


### PR DESCRIPTION
We have the following issue: If we create a download shortly before the end of the day, then the time_of_download might be already new day, though the data is from the last day. Hence, we need to parse the data from the data.

Testplan:
```
Execute on current main branch:
python -m dune_api_scripts.store_query_result_for_todays_trading_data
Execute on this branch:
python -m dune_api_scripts.store_query_result_for_todays_trading_data
```
Check that the answer is the same, e.g.

>Written updates to: data/dune_data/user_data/user_data_from1638403200.json
