### PR TITLE
WIP - Push App Data Json to user generated view

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,7 @@ python -m dune_api_scripts.store_query_result_for_todays_trading_data
 Update query:
 ```
 python -m dune_api_scripts.modify_and_execute_dune_query_for_entire_history_trading_data
-python -m dune_api_scripts.modify_and_execute_dune_query_for_todays_trading_volume
+python -m dune_api_scripts.modify_and_execute_dune_query_for_todays_trading_data
 python -m dune_api_scripts.execute_dune_query_for_all_app_data
 ```
 

--- a/dune_api_scripts/tests/test_utils.py
+++ b/dune_api_scripts/tests/test_utils.py
@@ -1,7 +1,7 @@
 import time
 import unittest
 
-from ..utils import ensure_that_download_is_recent
+from ..utils import ensure_that_download_is_recent, dune_address
 
 
 class MyTestCase(unittest.TestCase):
@@ -11,6 +11,14 @@ class MyTestCase(unittest.TestCase):
             ensure_that_download_is_recent(now, 50)
 
         self.assertEqual(ensure_that_download_is_recent(now, 100), None)
+
+    def test_dune_address(self):
+        hex_address = "0xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737"
+        self.assertEqual(
+            dune_address(hex_address),
+            "\\xca8e1b4e6846bdd9c59befb38a036cfbaa5f3737"
+        )
+
 
 
 if __name__ == '__main__':

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -1,20 +1,24 @@
 """Modifies and executed dune query for today's data"""
 from os import getenv
 
-from .utils import dune_from_environment, build_string_for_affiliate_referrals_pairs
+from .utils import dune_from_environment, app_data_entries
 
 if __name__ == "__main__":
     # initialize the environment
     dune = dune_from_environment()
+    VALUES = app_data_entries()
 
     # build query
-    QUERY = f"""CREATE OR REPLACE VIEW
+    QUERY = f"""
+    CREATE OR REPLACE VIEW
     dune_user_generated.gp_appdata (app_data, referrer)
-    AS VALUES {build_string_for_affiliate_referrals_pairs()}"""
+    AS VALUES {VALUES};"""
 
     # update query in dune
     query_id = int(getenv('QUERY_ID_ALL_APP_DATA', "257782"))
+
     dune.initiate_new_query(query_id, query=QUERY)
 
     # run query in dune
     dune.execute_query(query_id)
+    # Check out the results here: https://dune.xyz/queries/257782

--- a/dune_api_scripts/utils.py
+++ b/dune_api_scripts/utils.py
@@ -86,6 +86,7 @@ def build_string_for_affiliate_referrals_pairs():
 
 
 def load_app_data_content_map():
+    """Loads and returns App Data file from persistent storage"""
     file_path = Path(os.environ['APP_DATA_REFERRAL_RELATION_FILE'])
     if not file_path.is_file():
         # Must wait for the app_data-referrals relationships to be created,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use gpdata::health::HttpHealthEndpoint;
 use gpdata::in_memory_maintenance::in_memory_database_maintaince;
 use gpdata::models::in_memory_database::DatabaseStruct;
 use gpdata::models::in_memory_database::InMemoryDatabase;
-use gpdata::models::referral_store::ReferralStore;
+use gpdata::models::referral_store::ContentStore;
 use gpdata::referral_maintenance::referral_maintenance;
 use gpdata::serve_task;
 use gpdata::tracing_helper::initialize;
@@ -44,7 +44,7 @@ async fn main() {
         dune_download_folder.clone(),
         health,
     ));
-    let referral_store = ReferralStore::new(Vec::new());
+    let referral_store = ContentStore::new(Vec::new());
     let referral_maintenance_task = tokio::task::spawn(referral_maintenance(
         Arc::new(referral_store),
         dune_download_folder.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,21 +39,21 @@ async fn main() {
     let memory_database = Arc::new(InMemoryDatabase(Mutex::new(DatabaseStruct::default())));
     let health = Arc::new(HttpHealthEndpoint::new());
     let serve_task = serve_task(memory_database.clone(), args.bind_address, health.clone());
-    let maintance_task = tokio::task::spawn(in_memory_database_maintaince(
+    let maintenance_task = tokio::task::spawn(in_memory_database_maintaince(
         memory_database.clone(),
         dune_download_folder.clone(),
         health,
     ));
     let referral_store = ReferralStore::new(Vec::new());
-    let referral_maintance_task = tokio::task::spawn(referral_maintenance(
+    let referral_maintenance_task = tokio::task::spawn(referral_maintenance(
         Arc::new(referral_store),
         dune_download_folder.clone(),
         referral_data_folder,
         args.retrys_for_ipfs_file_fetching,
     ));
     tokio::select! {
-        result = referral_maintance_task => tracing::error!(?result, "referral maintance task exited"),
-        result = maintance_task => tracing::error!(?result, "maintance task exited"),
+        result = referral_maintenance_task => tracing::error!(?result, "referral maintenance task exited"),
+        result = maintenance_task => tracing::error!(?result, "maintenance task exited"),
         result = serve_task => tracing::error!(?result, "serve task exited"),
     };
 }

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -26,6 +26,15 @@ pub struct AppData {
     pub app_code: String,
     pub metadata: Option<Metadata>,
 }
+
+impl AppData {
+    pub fn read_referrer(&self) -> Option<H160> {
+        self.metadata
+            .as_ref()
+            .and_then(|metadata| Some(metadata.referrer.as_ref()?.address))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/models/dune_json_formats.rs
+++ b/src/models/dune_json_formats.rs
@@ -77,6 +77,6 @@ mod tests {
             time_of_download: Utc.ymd(2021, 8, 30).and_hms(14, 29, 51),
         };
         let derived_dune_json: DuneJson = serde_json::from_value(value).unwrap();
-        assert!(derived_dune_json == expected_value);
+        assert_eq!(derived_dune_json, expected_value);
     }
 }

--- a/src/models/referral_store.rs
+++ b/src/models/referral_store.rs
@@ -1,19 +1,20 @@
 extern crate serde;
 extern crate serde_derive;
-use primitive_types::{H160, H256};
+use crate::models::app_data_json_format::AppData;
+use primitive_types::H256;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Referral {
-    Address(Option<H160>),
+pub enum AppDataEntry {
+    Data(Option<AppData>),
     TryToFetchXTimes(u64),
 }
 
 #[derive(Debug)]
 pub struct AppDataStruct {
-    pub app_data: HashMap<H256, Referral>,
+    pub app_data: HashMap<H256, AppDataEntry>,
 }
 
 #[derive(Debug)]
@@ -23,7 +24,7 @@ impl ReferralStore {
     pub fn new(app_data_hashes: Vec<H256>) -> Self {
         let mut hm = HashMap::new();
         for hash in app_data_hashes {
-            hm.insert(hash, Referral::TryToFetchXTimes(3));
+            hm.insert(hash, AppDataEntry::TryToFetchXTimes(3));
         }
         let app_data_struct = AppDataStruct { app_data: hm };
         ReferralStore(Mutex::new(app_data_struct))
@@ -36,21 +37,10 @@ impl Serialize for AppDataStruct {
         S: Serializer,
     {
         let mut map = serializer.serialize_map(Some(self.app_data.keys().len()))?;
-        for (hash, address) in &self.app_data {
-            let mut bytes = [0u8; 2 + 32 * 2];
-            bytes[..2].copy_from_slice(b"0x");
-            // Can only fail if the buffer size does not match but we know it is correct.
-            hex::encode_to_slice(hash, &mut bytes[2..]).unwrap();
-            // Hex encoding is always valid utf8.
-            let hash_serialized = std::str::from_utf8(&bytes).unwrap();
-
-            if let Referral::Address(Some(address_bytes)) = address {
-                let mut bytes = [0u8; 2 + 20 * 2];
-                bytes[..2].copy_from_slice(b"0x");
-                // Can only fail if the buffer size does not match but we know it is correct.
-                hex::encode_to_slice(address_bytes, &mut bytes[2..]).unwrap();
-                let address_serialized = std::str::from_utf8(&bytes).unwrap();
-                map.serialize_entry(&hash_serialized, &address_serialized.to_string())?
+        for (hash, data) in &self.app_data {
+            // Skip every entry that is not `TryToFetchXTimes` or None
+            if let AppDataEntry::Data(Some(app_data)) = data {
+                map.serialize_entry(&hash, &app_data)?
             }
         }
         map.end()
@@ -60,6 +50,7 @@ impl Serialize for AppDataStruct {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::app_data_json_format::{Metadata, Referrer};
     use serde_json;
     use serde_json::json;
 
@@ -68,22 +59,45 @@ mod tests {
         let mut app_data_struct: AppDataStruct = AppDataStruct {
             app_data: HashMap::new(),
         };
-        app_data_struct.app_data.insert(
-            "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4"
-                .parse()
-                .unwrap(),
-            Referral::Address(Some(
-                "0x8c35b7ee520277d14af5f6098835a584c337311b"
-                    .parse()
-                    .unwrap(),
-            )),
-        );
-        let expected_serialization = json!(
-           { "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4":"0x8c35b7ee520277d14af5f6098835a584c337311b"});
+        let key: H256 = "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4"
+            .parse()
+            .unwrap();
+        let entry = AppData {
+            version: "1.2.3".to_string(),
+            app_code: "MooSwap".to_string(),
+            metadata: Some(Metadata {
+                environment: Some("production".to_string()),
+                referrer: Some(Referrer {
+                    // Note that serialization turns everything to lowercase...
+                    address: "0x8c35b7ee520277d14af5f6098835a584c337311b"
+                        .parse()
+                        .unwrap(),
+                    version: "6.6.6".to_string(),
+                }),
+            }),
+        };
 
+        app_data_struct
+            .app_data
+            .insert(key, AppDataEntry::Data(Some(entry)));
+
+        let expected_serialization = json!(
+        {
+            "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4":{
+                 "version":"1.2.3",
+                 "appCode":"MooSwap",
+                 "metadata":{
+                     "environment": "production",
+                     "referrer":{
+                         "address":"0x8c35b7ee520277d14af5f6098835a584c337311b",
+                         "version":"6.6.6"
+                 }
+            }
+         }
+        });
         assert_eq!(
-            serde_json::to_string(&app_data_struct).unwrap(),
-            serde_json::to_string(&expected_serialization).unwrap()
+            serde_json::to_value(&app_data_struct).unwrap(),
+            expected_serialization
         );
     }
 }

--- a/src/models/referral_store.rs
+++ b/src/models/referral_store.rs
@@ -18,16 +18,16 @@ pub struct AppDataStruct {
 }
 
 #[derive(Debug)]
-pub struct ReferralStore(pub Mutex<AppDataStruct>);
+pub struct ContentStore(pub Mutex<AppDataStruct>);
 
-impl ReferralStore {
+impl ContentStore {
     pub fn new(app_data_hashes: Vec<H256>) -> Self {
         let mut hm = HashMap::new();
         for hash in app_data_hashes {
             hm.insert(hash, AppDataEntry::TryToFetchXTimes(3));
         }
         let app_data_struct = AppDataStruct { app_data: hm };
-        ReferralStore(Mutex::new(app_data_struct))
+        ContentStore(Mutex::new(app_data_struct))
     }
 }
 


### PR DESCRIPTION
AppData Serialization. 

The purpose of this change is to change the App Data fetching by CID to parse and store all `AppData` in memory (rather than just the referrer). This way we can push the table of hash to referrer in the same way we already were, but also create a view of type `[ AppDataHash | AppDataJson ]` that will be useful as a building block for other purposes.

Some other things done here (I can split them up if its easier)

- Typos
- Introduce a helper method `dune_address` and test it
- Rework the Serialization of `AppData` - I am still having issues with the address (H160) field that is being converted to lower case... 

It is important to note that some of the logic involving the `build_string_for_affiliate_referrals_pairs` has changed so we will want to ensure it it backwards compatible. Not sure if there is a test for this.
