### PR TITLE
first attempt at dune error handling

### DIFF
--- a/dune_api_scripts/duneanalytics.py
+++ b/dune_api_scripts/duneanalytics.py
@@ -197,9 +197,15 @@ class DuneAnalytics:
 
 
 def handle_dune_response(response: Response, message: str = "successful response:"):
+    """
+    Parses response for errors by key and raises runtime error if they exist.
+    Successful responses will be printed to std-out and response json returned
+    :param response: Response from dune api post
+    :param message: optional custom message to be displayed upon success
+    :return: response in json format
+    """
     response_json = response.json()
     if 'errors' in response_json:
         raise RuntimeError("Dune API Request failed with", response_json)
-    else:
-        print(message, response_json)
+    print(message, response_json)
     return response_json

--- a/dune_api_scripts/duneanalytics.py
+++ b/dune_api_scripts/duneanalytics.py
@@ -2,7 +2,7 @@
 
 """This provides the DuneAnalytics class implementation"""
 
-from requests import Session, Response
+from requests import Session
 
 # --------- Constants --------- #
 
@@ -127,10 +127,7 @@ class DuneAnalytics:
             "query": "mutation UpsertQuery($session_id: Int!, $object: queries_insert_input!, $on_conflict: queries_on_conflict!, $favs_last_24h: Boolean! = false, $favs_last_7d: Boolean! = false, $favs_last_30d: Boolean! = false, $favs_all_time: Boolean! = true) {\n  insert_queries_one(object: $object, on_conflict: $on_conflict) {\n    ...Query\n    favorite_queries(where: {user_id: {_eq: $session_id}}, limit: 1) {\n      created_at\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment Query on queries {\n  id\n  dataset_id\n  name\n  description\n  query\n  private_to_group_id\n  is_temp\n  is_archived\n  created_at\n  updated_at\n  schedule\n  tags\n  parameters\n  user {\n    ...User\n    __typename\n  }\n  visualizations {\n    id\n    type\n    name\n    options\n    created_at\n    __typename\n  }\n  forked_query {\n    id\n    name\n    user {\n      name\n      __typename\n    }\n    __typename\n  }\n  query_favorite_count_all @include(if: $favs_all_time) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_24h @include(if: $favs_last_24h) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_7d @include(if: $favs_last_7d) {\n    favorite_count\n    __typename\n  }\n  query_favorite_count_last_30d @include(if: $favs_last_30d) {\n    favorite_count\n    __typename\n  }\n  __typename\n}\n\nfragment User on users {\n  id\n  name\n  profile_image_url\n  __typename\n}\n"
         }
 
-        self.session.headers.update({'authorization': f'Bearer {self.token}'})
-
-        response = self.session.post(GRAPH_URL, json=query_data)
-        handle_dune_response(response, "New query has been posted with response:")
+        self.handle_dune_request(query_data, "New query has been posted with response:")
 
     def execute_query(self, query_id):
         """
@@ -147,9 +144,7 @@ class DuneAnalytics:
                 "{\n  execute_query(query_id: $query_id, parameters: $parameters) "
                 "{\n    job_id\n    __typename\n  }\n}\n"}
 
-        self.session.headers.update({'authorization': f'Bearer {self.token}'})
-        response = self.session.post(GRAPH_URL, json=query_data)
-        handle_dune_response(response, "query executed successfully with response:")
+        self.handle_dune_request(query_data, "success: executed query with response")
 
     def query_result_id(self, query_id):
         """
@@ -165,10 +160,7 @@ class DuneAnalytics:
                      "{\n    job_id\n    result_id\n    __typename\n  }\n}\n"
         }
 
-        self.session.headers.update({'authorization': f'Bearer {self.token}'})
-
-        response = self.session.post(GRAPH_URL, json=query_data)
-        data = handle_dune_response(response, "success with response")
+        data = self.handle_dune_request(query_data, "success with response")
         result_id = data.get('data').get('get_result').get('result_id')
         return result_id
 
@@ -190,22 +182,24 @@ class DuneAnalytics:
                      "{\n    data\n    __typename\n  }\n}\n"
         }
 
+        return self.handle_dune_request(query_data)
+
+    def handle_dune_request(
+            self,
+            query,
+            message: str = "successful response:"
+    ):
+        """
+        Parses response for errors by key and raises runtime error if they exist.
+        Successful responses will be printed to std-out and response json returned
+        :param query: JSON content for request POST
+        :param message: optional custom message to be displayed upon success
+        :return: response in json format
+        """
         self.session.headers.update({'authorization': f'Bearer {self.token}'})
-
-        response = self.session.post(GRAPH_URL, json=query_data)
-        return handle_dune_response(response)
-
-
-def handle_dune_response(response: Response, message: str = "successful response:"):
-    """
-    Parses response for errors by key and raises runtime error if they exist.
-    Successful responses will be printed to std-out and response json returned
-    :param response: Response from dune api post
-    :param message: optional custom message to be displayed upon success
-    :return: response in json format
-    """
-    response_json = response.json()
-    if 'errors' in response_json:
-        raise RuntimeError("Dune API Request failed with", response_json)
-    print(message, response_json)
-    return response_json
+        response = self.session.post(GRAPH_URL, json=query)
+        response_json = response.json()
+        if 'errors' in response_json:
+            raise RuntimeError("Dune API Request", query, " failed with", response_json)
+        print(message, response_json)
+        return response_json


### PR DESCRIPTION
Raises `RuntimeError` on Dune API failures

This isn't "great" but it is a decent start that should do what we hope for. If any of the four places result in an exception we don't want to "raise" then we can catch it and just log the output. 

MUST BE TESTED in case of failure before merge.

In order to be more professional here, we should use a real logging library instead of all these print statements.

As a follow up to this "dirty hot fix" we should integrate the following logging tool: https://docs.python.org/3/library/logging.html#logging.error

I will start another PR introducing following up on this with real logging ASAP.
